### PR TITLE
Add hardcoded include paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ class OverrideSystemIncludeOrderBuildCommand(build_ext):
 
     def build_extension(self,ext):
         # Load includes from module directories first!
-        include_dirs = []
+        include_dirs = ['/usr/local/include', '/usr/include']
         include_dirs.extend(self.strip_includes(self.compiler.compiler))
         include_dirs.extend(self.strip_includes(self.compiler.compiler_so))
         include_dirs.extend(self.strip_includes(self.compiler.compiler_cxx))


### PR DESCRIPTION
Fixes issue #18.

(Linux only, a more general solution should be found. But I had to reinstall pyspatialite on a virtualenv (and a new machine) and I wanted to fix this)

Cristian
